### PR TITLE
1.6.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,14 @@ Links
 
 ## Changelog
 
+### 1.6.0.1
+- Fixed bake rigify retarget not assigning action to rig after baking
+- Removes facial expression bone drivers on Rigifying (caused cyclic dependencies)
+- Re-importing/rebuilding materials on a character will reload any texture images that are being re-used from existing or previous imports, just in case they have been changed on disk.
+    - Except when the image has been modified by the user and has not yet been saved.
+
 ### 1.6.0
-- Rigifing character keeps meta-rig and allows for Re-Rigifying the control rig from the meta-rig.
+- Rigifying character keeps meta-rig and allows for Re-Rigifying the control rig from the meta-rig.
     - Useful for re-aligning bones, re-positioning face rig, etc...
 - First draft of (optional) Dual Specular skin shader (Eevee & Cycles) with specular micro details.
 - Added build options to generate drivers for Jaw, Eyes and Head bones from facial expression shape keys.

--- a/imageutils.py
+++ b/imageutils.py
@@ -77,6 +77,11 @@ def load_image(filename, color_space, processed_images = None, reuse_existing = 
                         i.alpha_mode = "CHANNEL_PACKED"
                     if processed_images is not None and i and image_md5 and not found:
                         processed_images.append([image_md5, i])
+                        if not i.is_dirty:
+                            utils.log_detail(f"Reloading image: {i.name}")
+                            i.reload()
+                        else:
+                            utils.log_info(f"Image {i.name} has been modified, keeping in-memory image.")
                     colorspace.set_image_color_space(i, color_space)
                     return i
 


### PR DESCRIPTION
Fixed bake rigify retarget not assigning actions to rig after baking 
Removes facial expression bone drivers on Rigifying (caused cyclic dependencies) 
Reloads images being re-used on import/build.