### PR TITLE
1.6.0.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Links
 
 ## Changelog
 
-### 1.6.0.2
+### 1.6.0.3
 - Fixed bake rigify retarget not assigning action to rig after baking
 - Removes facial expression bone drivers on Rigifying (caused cyclic dependencies)
 - Re-importing/rebuilding materials on a character will reload any texture images that are being re-used from existing or previous imports, just in case they have been changed on disk.
@@ -43,6 +43,9 @@ Links
 - NLA Bake fix.
 - Fix Generic character import.
 - Spring rig panels show if character is invalid for spring rigging.
+- Expression drivers for bones only apply to CC4 Ext and Std profiles
+- Bone drivers for direct visemes Ah and Oh added.
+- Viseme bone drivers now excluded when Jaw drivers are disabled.
 
 
 ### 1.6.0

--- a/__init__.py
+++ b/__init__.py
@@ -90,7 +90,7 @@ from . import colorspace
 bl_info = {
     "name": "CC/iC Tools",
     "author": "Victor Soupday",
-    "version": (1, 6, 0, 2),
+    "version": (1, 6, 0, 3),
     "blender": (2, 93, 0),
     "category": "Characters",
     "location": "3D View > Properties > CC/iC Pipeline",

--- a/drivers.py
+++ b/drivers.py
@@ -15,7 +15,7 @@
 # along with CC/iC Blender Tools.  If not, see <https://www.gnu.org/licenses/>.
 
 import bpy
-from . import utils, vars
+from . import meshutils, utils, vars
 from rna_prop_ui import rna_idprop_ui_create
 
 def make_driver_var(driver, var_type, var_name, target, target_type = "OBJECT", data_path = "", bone_target = "", transform_type = "", transform_space = ""):
@@ -98,6 +98,20 @@ SHAPE_KEY_DRIVERS = {
         "range": 100.0,
         "translate": [0,0,0],
         "rotate": [0,0,18.0],
+    },
+
+    "Ah": {
+        "bone": ["CC_Base_JawRoot","jaw_master"],
+        "range": 100.0,
+        "translate": [0,0,0],
+        "rotate": [0,0,18.0],
+    },
+
+    "Oh": {
+        "bone": ["CC_Base_JawRoot","jaw_master"],
+        "range": 100.0,
+        "translate": [0,0,0],
+        "rotate": [0,0,12.0],
     },
 
     "Jaw_Open": {
@@ -353,7 +367,14 @@ def add_facial_shape_key_bone_drivers(chr_cache, jaw, eye_look, head):
         translate = SHAPE_KEY_DRIVERS[key_name]["translate"]
         rotate = SHAPE_KEY_DRIVERS[key_name]["rotate"]
 
+        if not meshutils.find_shape_key(body, key_name):
+            utils.log_info(f"Shape-key: {key_name} not found, skipping.")
+            continue
+
         if ((key_name.startswith("Jaw_") and not jaw) or
+            (key_name.startswith("V_") and not jaw) or
+            (key_name == "Ah" and not jaw) or
+            (key_name == "Oh" and not jaw) or
             (key_name.startswith("Eye_") and not eye_look) or
             (key_name.startswith("Head_") and not head)):
             continue

--- a/importer.py
+++ b/importer.py
@@ -866,7 +866,12 @@ class CC3Import(bpy.types.Operator):
             if chr_cache.rigified:
                 drivers.clear_facial_shape_key_bone_drivers(chr_cache)
             else:
-                drivers.add_facial_shape_key_bone_drivers(chr_cache,
+                objects = chr_cache.get_all_objects(include_armature=False, of_type="MESH")
+                facial_profile, viseme_profile = meshutils.get_facial_profile(objects)
+                utils.log_info(f"Facial Profile: {facial_profile}")
+                utils.log_info(f"Viseme Profile: {viseme_profile}")
+                if facial_profile == "Std" or facial_profile == "Ext":
+                    drivers.add_facial_shape_key_bone_drivers(chr_cache,
                                                prefs.build_shape_key_bone_drivers_jaw,
                                                prefs.build_shape_key_bone_drivers_eyes,
                                                prefs.build_shape_key_bone_drivers_head)

--- a/meshutils.py
+++ b/meshutils.py
@@ -274,6 +274,77 @@ def get_viseme_profile(objects):
     return vars.CC3_VISEME_NAMES
 
 
+def get_facial_profile(objects):
+    expressionProfile = "None"
+    visemeProfile = "None"
+
+    for obj in objects:
+
+        if (find_shape_key(obj, "Move_Jaw_Down") or
+            find_shape_key(obj, "Turn_Jaw_Down") or
+            find_shape_key(obj, "Move_Jaw_Down") or
+            find_shape_key(obj, "Move_Jaw_Down")):
+            expressionProfile = "Traditional"
+
+        if (find_shape_key(obj, "A01_Brow_Inner_Up") or
+            find_shape_key(obj, "A06_Eye_Look_Up_Left") or
+            find_shape_key(obj, "A15_Eye_Blink_Right") or
+            find_shape_key(obj, "A25_Jaw_Open") or
+            find_shape_key(obj, "A37_Mouth_Close")):
+            if (expressionProfile == "None" or
+                expressionProfile == "Traditional"):
+                expressionProfile = "ExPlus"
+
+        if (find_shape_key(obj, "Ear_Up_L") or
+            find_shape_key(obj, "Ear_Up_R") or
+            find_shape_key(obj, "Eyelash_Upper_Up_L") or
+            find_shape_key(obj, "Eyelash_Upper_Up_R") or
+            find_shape_key(obj, "Eye_L_Look_L") or
+            find_shape_key(obj, "Eye_R_Look_R")):
+            if (expressionProfile == "None" or
+                expressionProfile == "Std"):
+                expressionProfile = "Ext"
+
+        if (find_shape_key(obj, "Mouth_L") or
+            find_shape_key(obj, "Mouth_R") or
+            find_shape_key(obj, "Eye_Wide_L") or
+            find_shape_key(obj, "Eye_Wide_R") or
+            find_shape_key(obj, "Mouth_Smile") or
+            find_shape_key(obj, "Eye_Blink")):
+            if expressionProfile == "None":
+                expressionProfile = "Std"
+
+
+        if (find_shape_key(obj, "V_Open") or
+            find_shape_key(obj, "V_Tight") or
+            find_shape_key(obj, "V_Tongue_up") or
+            find_shape_key(obj, "V_Tongue_Raise")):
+            visemeProfile = "PairsCC4"
+
+        if (find_shape_key(obj, "Open") or
+            find_shape_key(obj, "Tight") or
+            find_shape_key(obj, "Tongue_up") or
+            find_shape_key(obj, "Tongue_Raise")):
+            if (visemeProfile == "PairsCC4" or
+                visemeProfile == "Direct"):
+                visemeProfile = "PairsCC3"
+
+        if (find_shape_key(obj, "AE") or
+            find_shape_key(obj, "EE") or
+            find_shape_key(obj, "Er") or
+            find_shape_key(obj, "Oh")):
+            if visemeProfile == "None":
+                visemeProfile = "Direct"
+
+        if (find_shape_key(obj, "Brow_Raise_Inner_Left") or
+            find_shape_key(obj, "Brow_Raise_Outer_Left") or
+            find_shape_key(obj, "Brow_Drop_Left") or
+            find_shape_key(obj, "Brow_Raise_Right")):
+            corrections = True
+
+    return expressionProfile, visemeProfile
+
+
 def set_shading(obj, smooth=True):
     if utils.object_exists_is_mesh(obj):
         for poly in obj.data.polygons:


### PR DESCRIPTION
expression drivers for bones only apply to CC4 Ext and Std profiles, drivers for direct visemes Ah and Oh added. Viseme drivers now excluded when Jaw drivers are disabled.