### PR TITLE
Add set_keyframes

### DIFF
--- a/importer.py
+++ b/importer.py
@@ -888,6 +888,11 @@ class CC3Import(bpy.types.Operator):
         default = True
     )
 
+    set_keyframes: bpy.props.BoolProperty(
+        name = "Set Keyframes",
+        default = True
+    )
+
     use_anim: bpy.props.BoolProperty(name = "Import Animation", description = "Import animation with character.\nWarning: long animations take a very long time to import in Blender 2.83", default = True)
 
     zoom: bpy.props.BoolProperty(


### PR DESCRIPTION
I've corrected the missing property from the first pull request. I didn't properly stash my changes the first time.

I've added the ability to send a pose to Blender without creating the action for the armature or shapekeys, or changing the timeline frame start and end.

This is helpful when the user needs to adjust the pose of the avatar inside of Blender using the pose editor inside of CC/IC without affecting anything else.

Tested with CC 4.52.3526.1 and IC 8.52.3605.1 and Blender 4.3.2

This is the button that toggles it on and off. The default is the existing behavior.

![398980040-2755818c-fa22-4d12-a32f-c4e93682560d](https://github.com/user-attachments/assets/b1598bf1-b123-4c64-865d-771d89aaa24d)
